### PR TITLE
Créer et tester les fichiers spec des services

### DIFF
--- a/src/services/PlayerService.spec.ts
+++ b/src/services/PlayerService.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IHttpClient } from '../core/http/HttpClient';
+import type { ICacheAdapter } from '../core/cache/ICacheAdapter';
+import type { ILogger } from '../core/log/ILogger';
+import { Metrics } from '../core/metrics/Metrics';
+import type { Player } from '../models/Player';
+
+import { PlayerService } from './PlayerService';
+
+/* ------------------------------------------------------------------------- *
+ * Test doubles
+ * ------------------------------------------------------------------------- */
+
+class MockHttpClient implements IHttpClient {
+  public calls = 0;
+  public lastUrl: string | null = null;
+  constructor(private readonly body: string = '<html></html>') {}
+
+  async get(url: string): Promise<string> {
+    this.calls += 1;
+    this.lastUrl = url;
+    return this.body;
+  }
+}
+
+class DummyCacheAdapter implements ICacheAdapter {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key) as T | undefined;
+  }
+
+  set<T>(key: string, value: T): void {
+    this.store.set(key, value);
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const dummyLogger: ILogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => dummyLogger,
+};
+
+/* ------------------------------------------------------------------------- *
+ * Mock the heavy DOM parser so we don't rely on large HTML fixtures.
+ * ------------------------------------------------------------------------- */
+
+const mockPlayer: Player = {
+  id: '23',
+  url: 'https://www.vlr.gg/player/23',
+  alias: 'TestPlayer',
+  realName: 'Test Real',
+  avatarUrl: '',
+  country: { name: 'Neverland', code: 'nl' },
+  socials: [],
+  totalWinnings: '$0',
+  agentStats: { timespan: '60d', stats: [] },
+  recentMatches: [],
+  teams: [],
+  eventPlacements: [],
+  news: [],
+};
+
+vi.mock('../parsers/player/PlayerParser', () => {
+  return {
+    PlayerParser: class {
+      constructor() {}
+      parse() {
+        return mockPlayer;
+      }
+    },
+  };
+});
+
+/* ------------------------------------------------------------------------- */
+
+let cache: DummyCacheAdapter;
+let metrics: Metrics;
+let http: MockHttpClient;
+let service: PlayerService;
+
+beforeEach(() => {
+  cache = new DummyCacheAdapter();
+  metrics = new Metrics();
+  http = new MockHttpClient();
+  service = new PlayerService(http, cache, dummyLogger, metrics);
+});
+
+describe('PlayerService', () => {
+  it('fetches a player and stores it in cache on first call', async () => {
+    const envelope = await service.getById('23', true);
+
+    expect(http.calls).toBe(1);
+    expect(http.lastUrl).toBe('https://www.vlr.gg/player/23');
+
+    expect(envelope.data).toEqual(mockPlayer);
+    expect(envelope.info.fromCache).toBe(false);
+
+    const cached = cache.get<Player>('https://www.vlr.gg/player/23');
+    expect(cached).toEqual(mockPlayer);
+  });
+
+  it('uses cache on subsequent calls', async () => {
+    await service.getById('23', true);
+    expect(http.calls).toBe(1);
+
+    const envelopeCached = await service.getById('23', true);
+    expect(http.calls).toBe(1); // still one call
+    expect(envelopeCached.info.fromCache).toBe(true);
+  });
+
+  it('ignores cache when useCache=false', async () => {
+    await service.getById('23', true);
+    expect(http.calls).toBe(1);
+
+    const envelopeNoCache = await service.getById('23', false);
+    expect(http.calls).toBe(2);
+    expect(envelopeNoCache.info.fromCache).toBe(false);
+  });
+});

--- a/src/services/SearchService.spec.ts
+++ b/src/services/SearchService.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IHttpClient } from '../core/http/HttpClient';
+import type { ICacheAdapter } from '../core/cache/ICacheAdapter';
+import type { ILogger } from '../core/log/ILogger';
+import { Metrics } from '../core/metrics/Metrics';
+import type { SearchResult } from '../models/Search';
+
+import { SearchService } from './SearchService';
+
+/* ------------------------------------------------------------------------- *
+ * Test doubles
+ * ------------------------------------------------------------------------- */
+
+class MockHttpClient implements IHttpClient {
+  public calls = 0;
+  public lastUrl: string | null = null;
+  constructor(private readonly body: string = '<html></html>') {}
+
+  async get(url: string): Promise<string> {
+    this.calls += 1;
+    this.lastUrl = url;
+    return this.body;
+  }
+}
+
+class DummyCacheAdapter implements ICacheAdapter {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key) as T | undefined;
+  }
+
+  set<T>(key: string, value: T): void {
+    this.store.set(key, value);
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const dummyLogger: ILogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => dummyLogger,
+};
+
+/* ------------------------------------------------------------------------- *
+ * Mock SearchParser
+ * ------------------------------------------------------------------------- */
+
+const mockResults: SearchResult[] = [
+  {
+    id: '42',
+    url: 'https://www.vlr.gg/player/42',
+    name: 'Foo',
+    imageUrl: '',
+    description: 'bar',
+    type: 'player',
+  },
+];
+
+vi.mock('../parsers/search/SearchParser', () => {
+  return {
+    SearchParser: class {
+      constructor() {}
+      parse() {
+        return mockResults;
+      }
+    },
+  };
+});
+
+/* ------------------------------------------------------------------------- */
+
+let cache: DummyCacheAdapter;
+let metrics: Metrics;
+let http: MockHttpClient;
+let service: SearchService;
+
+beforeEach(() => {
+  cache = new DummyCacheAdapter();
+  metrics = new Metrics();
+  http = new MockHttpClient();
+  service = new SearchService(http, cache, dummyLogger, metrics);
+});
+
+describe('SearchService', () => {
+  it('fetches results and stores them in cache on first call', async () => {
+    const envelope = await service.getResults('foo', 'players', true);
+
+    const expectedUrl = 'https://www.vlr.gg/search/?q=foo&type=players';
+    expect(http.calls).toBe(1);
+    expect(http.lastUrl).toBe(expectedUrl);
+
+    expect(envelope.data).toEqual(mockResults);
+    expect(envelope.info.fromCache).toBe(false);
+
+    const cached = cache.get<SearchResult[]>(expectedUrl);
+    expect(cached).toEqual(mockResults);
+  });
+
+  it('uses cache on subsequent calls', async () => {
+    await service.getResults('foo', 'players', true);
+    expect(http.calls).toBe(1);
+
+    const envelopeCached = await service.getResults('foo', 'players', true);
+    expect(http.calls).toBe(1);
+    expect(envelopeCached.info.fromCache).toBe(true);
+  });
+
+  it('ignores cache when useCache=false', async () => {
+    await service.getResults('foo', 'players', true);
+    expect(http.calls).toBe(1);
+
+    const envelopeNoCache = await service.getResults('foo', 'players', false);
+    expect(http.calls).toBe(2);
+    expect(envelopeNoCache.info.fromCache).toBe(false);
+  });
+});

--- a/src/services/TeamMatchesService.spec.ts
+++ b/src/services/TeamMatchesService.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IHttpClient } from '../core/http/HttpClient';
+import type { ICacheAdapter } from '../core/cache/ICacheAdapter';
+import type { ILogger } from '../core/log/ILogger';
+import { Metrics } from '../core/metrics/Metrics';
+import type { TeamMatch } from '../models/TeamMatch';
+
+import { TeamMatchesService } from './TeamMatchesService';
+
+/* ------------------------------------------------------------------------- */
+
+class MockHttpClient implements IHttpClient {
+  public calls = 0;
+  public lastUrl: string | null = null;
+  constructor(private readonly body: string = '<html></html>') {}
+
+  async get(url: string): Promise<string> {
+    this.calls += 1;
+    this.lastUrl = url;
+    return this.body;
+  }
+}
+
+class DummyCacheAdapter implements ICacheAdapter {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key) as T | undefined;
+  }
+
+  set<T>(key: string, value: T): void {
+    this.store.set(key, value);
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const dummyLogger: ILogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => dummyLogger,
+};
+
+/* ------------------------------------------------------------------------- *
+ * Mock TeamMatchesParser
+ * ------------------------------------------------------------------------- */
+
+const mockMatch: TeamMatch = {
+  id: 'm1',
+  url: 'https://www.vlr.gg/m1',
+  event: { name: 'Event', stage: 'Stage' },
+  opponent: { name: 'Opp', tag: 'TAG', logoUrl: undefined },
+  result: { own: 13, opponent: 10, status: 'win' },
+  vods: [],
+  date: 'Today',
+  games: [],
+  status: 'completed',
+};
+
+vi.mock('../parsers/team/TeamMatchesParser', () => {
+  return {
+    TeamMatchesParser: class {
+      constructor() {}
+      parse() {
+        return { matches: [mockMatch], hasNextPage: false };
+      }
+    },
+  };
+});
+
+/* ------------------------------------------------------------------------- */
+
+let cache: DummyCacheAdapter;
+let metrics: Metrics;
+let http: MockHttpClient;
+let service: TeamMatchesService;
+
+beforeEach(() => {
+  cache = new DummyCacheAdapter();
+  metrics = new Metrics();
+  http = new MockHttpClient();
+  service = new TeamMatchesService(http, cache, dummyLogger, metrics);
+});
+
+describe('TeamMatchesService', () => {
+  it('fetches matches list', async () => {
+    const envelope = await service.getByTeamId('1337', true);
+
+    expect(http.calls).toBe(1);
+    expect(http.lastUrl).toBe('https://www.vlr.gg/team/matches/1337/?page=1');
+
+    expect(envelope.data).toEqual([mockMatch]);
+    expect(envelope.info.fromCache).toBe(false);
+  });
+});

--- a/src/services/TeamService.spec.ts
+++ b/src/services/TeamService.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IHttpClient } from '../core/http/HttpClient';
+import type { ICacheAdapter } from '../core/cache/ICacheAdapter';
+import type { ILogger } from '../core/log/ILogger';
+import { Metrics } from '../core/metrics/Metrics';
+import type { Team } from '../models/Team';
+
+import { TeamService } from './TeamService';
+
+/* ------------------------------------------------------------------------- */
+
+class MockHttpClient implements IHttpClient {
+  public calls = 0;
+  public lastUrl: string | null = null;
+  constructor(private readonly body: string = '<html></html>') {}
+
+  async get(url: string): Promise<string> {
+    this.calls += 1;
+    this.lastUrl = url;
+    return this.body;
+  }
+}
+
+class DummyCacheAdapter implements ICacheAdapter {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key) as T | undefined;
+  }
+
+  set<T>(key: string, value: T): void {
+    this.store.set(key, value);
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const dummyLogger: ILogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => dummyLogger,
+};
+
+/* ------------------------------------------------------------------------- *
+ * Mock TeamParser
+ * ------------------------------------------------------------------------- */
+
+const mockTeam: Team = {
+  id: 't1',
+  url: 'https://www.vlr.gg/team/t1',
+  name: 'TeamFoo',
+  tag: 'FOO',
+  logoUrl: '',
+  country: 'Nowhere',
+  countryCode: 'nw',
+  website: null,
+  socials: [],
+  totalWinnings: '$0',
+  ranking: { rank: 1, region: 'WW', rating: 1000, record: { wins: 1, losses: 0 } },
+  roster: { players: [], staff: [] },
+  recentResults: [],
+  eventPlacements: [],
+  relatedNews: [],
+};
+
+vi.mock('../parsers/team/TeamParser', () => {
+  return {
+    TeamParser: class {
+      constructor() {}
+      parse() {
+        return mockTeam;
+      }
+    },
+  };
+});
+
+/* ------------------------------------------------------------------------- */
+
+let cache: DummyCacheAdapter;
+let metrics: Metrics;
+let http: MockHttpClient;
+let service: TeamService;
+
+beforeEach(() => {
+  cache = new DummyCacheAdapter();
+  metrics = new Metrics();
+  http = new MockHttpClient();
+  service = new TeamService(http, cache, dummyLogger, metrics);
+});
+
+describe('TeamService', () => {
+  it('fetches a team and caches it', async () => {
+    const envelope = await service.getById('t1', true);
+    expect(http.calls).toBe(1);
+    expect(http.lastUrl).toBe('https://www.vlr.gg/team/t1');
+    expect(envelope.data).toEqual(mockTeam);
+    expect(envelope.info.fromCache).toBe(false);
+
+    const cached = cache.get<Team>('https://www.vlr.gg/team/t1');
+    expect(cached).toEqual(mockTeam);
+  });
+});

--- a/src/services/TeamTransactionService.spec.ts
+++ b/src/services/TeamTransactionService.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IHttpClient } from '../core/http/HttpClient';
+import type { ICacheAdapter } from '../core/cache/ICacheAdapter';
+import type { ILogger } from '../core/log/ILogger';
+import { Metrics } from '../core/metrics/Metrics';
+import type { TeamTransaction } from '../models/TeamTransaction';
+
+import { TeamTransactionService } from './TeamTransactionService';
+
+/* ------------------------------------------------------------------------- */
+
+class MockHttpClient implements IHttpClient {
+  public calls = 0;
+  public lastUrl: string | null = null;
+  constructor(private readonly body: string = '<html></html>') {}
+
+  async get(url: string): Promise<string> {
+    this.calls += 1;
+    this.lastUrl = url;
+    return this.body;
+  }
+}
+
+class DummyCacheAdapter implements ICacheAdapter {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key) as T | undefined;
+  }
+
+  set<T>(key: string, value: T): void {
+    this.store.set(key, value);
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const dummyLogger: ILogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => dummyLogger,
+};
+
+/* ------------------------------------------------------------------------- *
+ * Mock TeamTransactionParser
+ * ------------------------------------------------------------------------- */
+
+const mockTx: TeamTransaction = {
+  date: 'yesterday',
+  action: 'join',
+  player: { id: 'p1', url: 'https://vlr.gg/player/1', alias: 'Foo', realName: 'Foo Bar', countryCode: 'us' },
+  position: 'Duelist',
+  referenceUrl: undefined,
+};
+
+vi.mock('../parsers/team/TeamTransactionParser', () => {
+  return {
+    TeamTransactionParser: class {
+      constructor() {}
+      parse() {
+        return [mockTx];
+      }
+    },
+  };
+});
+
+/* ------------------------------------------------------------------------- */
+
+let cache: DummyCacheAdapter;
+let metrics: Metrics;
+let http: MockHttpClient;
+let service: TeamTransactionService;
+
+beforeEach(() => {
+  cache = new DummyCacheAdapter();
+  metrics = new Metrics();
+  http = new MockHttpClient();
+  service = new TeamTransactionService(http, cache, dummyLogger, metrics);
+});
+
+describe('TeamTransactionService', () => {
+  it('fetches transactions and caches them', async () => {
+    const envelope = await service.getByTeamId('42', true);
+    expect(http.calls).toBe(1);
+    expect(http.lastUrl).toBe('https://www.vlr.gg/team/transactions/42');
+    expect(envelope.data).toEqual([mockTx]);
+    expect(envelope.info.fromCache).toBe(false);
+  });
+});


### PR DESCRIPTION
Add unit tests for all service classes.

Each test isolates the service by mocking dependencies like HttpClient, cache, and logger. Heavy DOM parsers are also mocked to avoid reliance on large HTML fixtures. Scenarios cover initial data fetching, cache utilization, and forced cache invalidation.